### PR TITLE
Do not use a cache in DBMDataManager if the PointDriver already caches its points

### DIFF
--- a/src/dbm/DBMDataManager.vb
+++ b/src/dbm/DBMDataManager.vb
@@ -44,6 +44,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     ' method used for retrieving data.
 
 
+    Public Shared UseCache As Boolean = True
     Public PointDriver As DBMPointDriverAbstract
     Private Values As New Dictionary(Of DateTime, Double)
 
@@ -61,6 +62,10 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' cached in memory, and, if available for the requested timestamp, have
       ' preference over using the PointDriver object.
       ' Returns value at timestamp, either from cache or using driver
+
+      If Not UseCache Then
+        Return PointDriver.GetData(Timestamp, Timestamp.AddSeconds(CalculationInterval))
+      End If
 
       If Not Values.TryGetValue(Timestamp, Value) Then ' Not in cache
         Try

--- a/src/dbm/DBMMath.vb
+++ b/src/dbm/DBMMath.vb
@@ -264,10 +264,12 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim CentralTendency, MAD, ControlLimit As Double
       Dim i As Integer
 
+      Dim NonNaNCount As Integer = Values.Count(Function(v) Not IsNaN(v))
+
       CentralTendency = Median(Values)
       MAD = Median(AbsoluteDeviation(Values, CentralTendency))
-      ControlLimit = MAD*MedianAbsoluteDeviationScaleFactor(Values.Length-1)* _
-        ControlLimitRejectionCriterion(ConfidenceInterval, Values.Length-1)
+      ControlLimit = MAD*MedianAbsoluteDeviationScaleFactor(NonNaNCount)* _
+        ControlLimitRejectionCriterion(ConfidenceInterval, NonNaNCount)
 
       If ControlLimit = 0 Then ' This only happens when MAD equals 0.
         ' Use Mean Absolute Deviation instead of Median Absolute Deviation
@@ -276,8 +278,7 @@ Namespace Vitens.DynamicBandwidthMonitor
         CentralTendency = Mean(Values)
         MAD = Mean(AbsoluteDeviation(Values, CentralTendency))
         ControlLimit = MAD*MeanAbsoluteDeviationScaleFactor* _
-          ControlLimitRejectionCriterion(ConfidenceInterval, _
-          Values.Length-1)
+          ControlLimitRejectionCriterion(ConfidenceInterval, NonNaNCount)
       End If
 
       For i = 0 to Values.Length-1

--- a/src/dbm/DBMMath.vb
+++ b/src/dbm/DBMMath.vb
@@ -184,14 +184,18 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' Returns the arithmetic mean; the sum of the sampled values divided
       ' by the number of items in the sample.
 
+      Dim NonNaNCount As Integer = 0
       Dim Value As Double
+      Dim Sum As Double = 0
 
-      Mean = 0
       For Each Value In Values
-        Mean += Value/Values.Length
+        If Not IsNan(Value) Then
+          Sum += Value
+          NonNaNCount += 1
+        End If
       Next
 
-      Return Mean
+      Return Sum / NonNaNCount
 
     End Function
 
@@ -202,9 +206,18 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' a population, or a probability distribution, from the lower half. In
       ' simple terms, it may be thought of as the "middle" value of a data set.
 
-      Dim MedianValues(Values.Length-1) As Double
+      Dim NonNaNCount As Integer = Values.Count(Function(v) Not IsNaN(v))
+      Dim MedianValues(NonNaNCount-1) As Double
 
-      Array.Copy(Values, MedianValues, Values.Length)
+      ' Only use non NaN values
+      NonNaNCount = 0
+      For i as Integer = 0 to Values.Length-1
+        If Not IsNan(Values(i)) Then
+          MedianValues(NonNaNCount) = Values(i)
+          NonNaNCount += 1
+        End If
+      Next i
+
       Array.Sort(MedianValues)
 
       If MedianValues.Length Mod 2 = 0 Then

--- a/src/dbm/DBMPoint.vb
+++ b/src/dbm/DBMPoint.vb
@@ -67,7 +67,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
       Dim CorrelationCounter, EMACounter, PatternCounter As Integer
       Dim PredictionTimestamp, PatternTimestamp As DateTime
-      Dim Prediction As New DBMPrediction
+      Dim Prediction As DBMPrediction
       Dim Patterns(ComparePatterns), MeasuredValues(EMAPreviousPeriods), _
         PredictedValues(EMAPreviousPeriods), _
         LowerControlLimits(EMAPreviousPeriods), _
@@ -90,7 +90,7 @@ Namespace Vitens.DynamicBandwidthMonitor
               (-(EMAPreviousPeriods-EMACounter+CorrelationCounter)* _
               CalculationInterval) ' Timestamp for prediction results
             If Predictions.ContainsKey(PredictionTimestamp) Then ' From cache
-              Prediction = Predictions.Item(PredictionTimestamp).ShallowCopy
+              Prediction = Predictions.Item(PredictionTimestamp)
             Else ' Calculate prediction data
               For PatternCounter = 0 To ComparePatterns ' Data for regression.
                 PatternTimestamp = PredictionTimestamp. _
@@ -101,7 +101,7 @@ Namespace Vitens.DynamicBandwidthMonitor
                     SubtractPoint.DataManager.Value(PatternTimestamp)
                 End If
               Next PatternCounter
-              Prediction.Calculate(Patterns)
+              Prediction = DBMPrediction.Calculate(Patterns)
               ' Limit cache size
               Do While Predictions.Count >= MaxPointPredictions
                 ' Remove random cached value when cache limit reached.
@@ -109,7 +109,7 @@ Namespace Vitens.DynamicBandwidthMonitor
                   (RandomNumber(0, Predictions.Count-1)).Key)
               Loop
               ' Add calculated prediction to cache.
-              Predictions.Add(PredictionTimestamp, Prediction.ShallowCopy)
+              Predictions.Add(PredictionTimestamp, Prediction)
             End If
             With Prediction ' Store results in arrays for EMA calculation.
               MeasuredValues(EMACounter) = .MeasuredValue

--- a/src/dbm/DBMPoint.vb
+++ b/src/dbm/DBMPoint.vb
@@ -39,6 +39,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
     Public DataManager As DBMDataManager
     Private Predictions As New Dictionary(Of DateTime, DBMPrediction)
+    Private PredictionsQueue As New Queue(Of DateTime) ' Maintains insertion order of the Predictions Dictionary
     Private PredictionsSubtractPoint As DBMPoint
 
 
@@ -67,7 +68,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
       Dim CorrelationCounter, EMACounter, PatternCounter As Integer
       Dim PredictionTimestamp, PatternTimestamp As DateTime
-      Dim Prediction As DBMPrediction
+      Dim Prediction As DBMPrediction = Nothing
       Dim Patterns(ComparePatterns), MeasuredValues(EMAPreviousPeriods), _
         PredictedValues(EMAPreviousPeriods), _
         LowerControlLimits(EMAPreviousPeriods), _
@@ -78,6 +79,7 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' Can we reuse stored results?
       If SubtractPoint IsNot PredictionsSubtractPoint Then
         Predictions.Clear ' No, so clear results
+        PredictionsQueue.Clear
         PredictionsSubtractPoint = SubtractPoint
       End If
 
@@ -89,9 +91,8 @@ Namespace Vitens.DynamicBandwidthMonitor
             PredictionTimestamp = Timestamp.AddSeconds _
               (-(EMAPreviousPeriods-EMACounter+CorrelationCounter)* _
               CalculationInterval) ' Timestamp for prediction results
-            If Predictions.ContainsKey(PredictionTimestamp) Then ' From cache
-              Prediction = Predictions.Item(PredictionTimestamp)
-            Else ' Calculate prediction data
+            If Not Predictions.TryGetValue(PredictionTimestamp, Prediction) Then
+              ' Calculate prediction data
               For PatternCounter = 0 To ComparePatterns ' Data for regression.
                 PatternTimestamp = PredictionTimestamp. _
                   AddDays(-(ComparePatterns-PatternCounter)*7)
@@ -103,13 +104,13 @@ Namespace Vitens.DynamicBandwidthMonitor
               Next PatternCounter
               Prediction = DBMPrediction.Calculate(Patterns)
               ' Limit cache size
-              Do While Predictions.Count >= MaxPointPredictions
-                ' Remove random cached value when cache limit reached.
-                Predictions.Remove(Predictions.ElementAt _
-                  (RandomNumber(0, Predictions.Count-1)).Key)
+              Do While Predictions.Count >= MaxPointPredictions ' Limit cache
+                ' Use the Queue to select the least recently inserted timestamp
+                Predictions.Remove(PredictionsQueue.Dequeue())
               Loop
               ' Add calculated prediction to cache.
               Predictions.Add(PredictionTimestamp, Prediction)
+              PredictionsQueue.Enqueue(PredictionTimestamp)
             End If
             With Prediction ' Store results in arrays for EMA calculation.
               MeasuredValues(EMACounter) = .MeasuredValue

--- a/src/dbmtester/DBMTester.vb
+++ b/src/dbmtester/DBMTester.vb
@@ -95,6 +95,8 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim ErrorStats As DBMStatistics
       Dim CorrelationPoint As DBMCorrelationPoint
 
+      DBMDataManager.UseCache = False
+
       ' Parse command line arguments
       For Each CommandLineArg In GetCommandLineArgs
         ' Parameter=Value

--- a/src/dbmtester/DBMTester.vb
+++ b/src/dbmtester/DBMTester.vb
@@ -28,6 +28,7 @@ Imports System
 Imports System.Collections.Generic
 Imports System.Environment
 Imports System.Globalization.CultureInfo
+Imports System.Text
 Imports System.Text.RegularExpressions
 Imports Vitens.DynamicBandwidthMonitor.DBMParameters
 
@@ -159,15 +160,16 @@ Namespace Vitens.DynamicBandwidthMonitor
           EndTimestamp = EndTimestamp.AddSeconds(-CalculationInterval)
         End If
         Do While StartTimestamp <= EndTimestamp
-          Console.Write(FormatDateTime(StartTimestamp) & Separator)
+          Dim Line as New StringBuilder()
+          Line.Append(FormatDateTime(StartTimestamp))
           Result = _DBM.Result _
             (InputPointDriver, CorrelationPoints, StartTimestamp)
           With Result
-            Console.Write(FormatNumber(.Factor) & Separator & _
-              FormatNumber(.Prediction.MeasuredValue) & Separator & _
-              FormatNumber(.Prediction.PredictedValue) & Separator & _
-              FormatNumber(.Prediction.LowerControlLimit) & Separator & _
-              FormatNumber(.Prediction.UpperControlLimit))
+            Line.Append(Separator).Append(FormatNumber(.Factor))
+            Line.Append(Separator).Append(FormatNumber(.Prediction.MeasuredValue))
+            Line.Append(Separator).Append(FormatNumber(.Prediction.PredictedValue))
+            Line.Append(Separator).Append(FormatNumber(.Prediction.LowerControlLimit))
+            Line.Append(Separator).Append(FormatNumber(.Prediction.UpperControlLimit))
           End With
           ' If an event is found and a correlation point is available
           If CorrelationPoints.Count > 0 And _
@@ -176,38 +178,36 @@ Namespace Vitens.DynamicBandwidthMonitor
               Result.RelativeErrors, Result.CorrelationAbsoluteErrors, _
               Result.CorrelationRelativeErrors}
               For Each PredictionError In PredictionErrors
-                Console.Write(Separator & FormatNumber(PredictionError))
+                Line.Append(Separator).Append(FormatNumber(PredictionError))
               Next
             Next
             For Each ErrorStats In {Result.AbsoluteErrorStats, _
               Result.RelativeErrorStats}
               With ErrorStats
-                Console.Write(Separator & _
-                  FormatNumber(.Count) & Separator & _
-                  FormatNumber(.Slope) & Separator & _
-                  FormatNumber(.OriginSlope) & Separator & _
-                  FormatNumber(.Angle) & Separator & _
-                  FormatNumber(.OriginAngle) & Separator & _
-                  FormatNumber(.Intercept) & Separator & _
-                  FormatNumber(.StandardError) & Separator & _
-                  FormatNumber(.Correlation) & Separator & _
-                  FormatNumber(.ModifiedCorrelation) & Separator & _
-                  FormatNumber(.Determination))
+                Line.Append(Separator).Append(FormatNumber(.Count))
+                Line.Append(Separator).Append(FormatNumber(.Slope))
+                Line.Append(Separator).Append(FormatNumber(.OriginSlope))
+                Line.Append(Separator).Append(FormatNumber(.Angle))
+                Line.Append(Separator).Append(FormatNumber(.OriginAngle))
+                Line.Append(Separator).Append(FormatNumber(.Intercept))
+                Line.Append(Separator).Append(FormatNumber(.StandardError))
+                Line.Append(Separator).Append(FormatNumber(.Correlation))
+                Line.Append(Separator).Append(FormatNumber(.ModifiedCorrelation))
+                Line.Append(Separator).Append(FormatNumber(.Determination))
               End With
             Next
             For Each CorrelationPoint In CorrelationPoints
               Result = _DBM.Result _
                 (CorrelationPoint.PointDriver, Nothing, StartTimestamp)
               With Result.Prediction
-                Console.Write(Separator & _
-                  FormatNumber(.MeasuredValue) & Separator & _
-                  FormatNumber(.PredictedValue) & Separator & _
-                  FormatNumber(.LowerControlLimit) & Separator & _
-                  FormatNumber(.UpperControlLimit))
+                Line.Append(Separator).Append(FormatNumber(.MeasuredValue))
+                Line.Append(Separator).Append(FormatNumber(.PredictedValue))
+                Line.Append(Separator).Append(FormatNumber(.LowerControlLimit))
+                Line.Append(Separator).Append(FormatNumber(.UpperControlLimit))
               End With
             Next
           End If
-          Console.WriteLine ' End of line
+          Console.WriteLine(Line.ToString())
           ' Next interval
           StartTimestamp = StartTimestamp.AddSeconds(CalculationInterval)
         Loop


### PR DESCRIPTION
This would be better controlled by asking the PointDriver directly whether it needs caching or not.
But that can be done best when the inheritance of the PointDriver is done properly.