### PR TITLE
Do not use a cache in DBMDataManager if the PointDriver already caches its points

### DIFF
--- a/src/dbm/DBMDataManager.vb
+++ b/src/dbm/DBMDataManager.vb
@@ -44,6 +44,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     ' method used for retrieving data.
 
 
+    Public Shared UseCache As Boolean = True
     Public PointDriver As DBMPointDriverAbstract
     Private Values As New Dictionary(Of DateTime, Double)
 
@@ -61,6 +62,10 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' cached in memory, and, if available for the requested timestamp, have
       ' preference over using the PointDriver object.
       ' Returns value at timestamp, either from cache or using driver
+
+      If Not UseCache Then
+        Return PointDriver.GetData(Timestamp, Timestamp.AddSeconds(CalculationInterval))
+      End If
 
       If Not Values.TryGetValue(Timestamp, Value) Then ' Not in cache
         Try

--- a/src/dbmtester/DBMTester.vb
+++ b/src/dbmtester/DBMTester.vb
@@ -95,6 +95,8 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim ErrorStats As DBMStatistics
       Dim CorrelationPoint As DBMCorrelationPoint
 
+      DBMDataManager.UseCache = False
+
       ' Parse command line arguments
       For Each CommandLineArg In GetCommandLineArgs
         ' Parameter=Value


### PR DESCRIPTION
This would be better controlled by asking the PointDriver directly whether it needs caching or not.
But that can be done best when the inheritance of the PointDriver is done properly.