### PR TITLE
Remove precomputed results

### DIFF
--- a/src/dbm/DBMMath.vb
+++ b/src/dbm/DBMMath.vb
@@ -61,11 +61,6 @@ Namespace Vitens.DynamicBandwidthMonitor
 
       Dim q, r As Double
 
-      ' Precomputed result
-      If p = 0.95 Then Return 1.64485362513334
-      If p = 0.99 Then Return 2.32634787438802
-      If p = 0.9999 Then Return 3.71901648212512
-
       If p < p_low Then ' Left tail
         q = Sqrt(-2*Log(p))
         Return (((((c1*q+c2)*q+c3)*q+c4)*q+c5)*q+c6)/
@@ -139,7 +134,7 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' R.C. Geary. The Ratio of the Mean Deviation to the Standard Deviation
       '  as a Test of Normality. Biometrika, 1935. Cited on page 8.
 
-      Return 1.2533141373155 ' Precomputed result for Sqrt(PI/2)
+      Return Sqrt(PI/2)
 
     End Function
 
@@ -151,9 +146,6 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' For a symmetric distribution with zero mean, the population MAD is the
       ' 75th percentile of the distribution.
       ' Huber, P. J. (1981). Robust statistics. New York: John Wiley.
-
-      ' Precomputed result
-      If n = 11 Then Return 1.43380414160658
 
       If n < 30 Then
         Return 1/TInv(0.75, n) ' n<30 Student's t-distribution
@@ -173,16 +165,6 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' Student. 1908. Probable error of a correlation
       '  coefficient. Biometrika 6, 2-3, 302–310.
       ' Hogg and Tanis' Probability and Statistical Inference (7e).
-
-      ' Precomputed results
-      If p = 0.99 Then
-        If n = 6 Then Return 3.70744533800376
-        If n = 7 Then Return 3.49948706845407
-        If n = 8 Then Return 3.35538805213598
-        If n = 9 Then Return 3.2498355357257
-        If n = 10 Then Return 3.16927251686568
-        If n = 11 Then Return 3.10580635664082
-      End If
 
       If n < 30 Then
         Return TInv((p+1)/2, n) ' n<30 Student's t-distribution
@@ -405,9 +387,6 @@ Namespace Vitens.DynamicBandwidthMonitor
     Public Shared Function SlopeToAngle(Slope As Double) As Double
 
       ' Returns angle in degrees for Slope.
-
-      ' Precomputed result
-      If Slope = 1 Then Return 45
 
       Return Atan(Slope)/(2*PI)*360
 


### PR DESCRIPTION
Takes a lot of effort to maintain frequently used parameters for these functions and performance only takes  a ~2% hit by removing these.