### PR TITLE
Analytics fix

### DIFF
--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -31,6 +31,8 @@ Imports System.Runtime.InteropServices
 Imports System.Threading
 Imports OSIsoft.AF.Asset
 Imports OSIsoft.AF.Asset.AFAttributeTrait
+Imports OSIsoft.AF.Asset.AFSystemStateCode
+Imports OSIsoft.AF.Asset.AFValue
 Imports OSIsoft.AF.Data
 Imports OSIsoft.AF.Time
 Imports Vitens.DynamicBandwidthMonitor.DBMInfo
@@ -247,15 +249,19 @@ Namespace Vitens.DynamicBandwidthMonitor
       timeContext As Object, inputAttributes As AFAttributeList,
       inputValues As AFValues) As AFValue
 
-      Dim Timestamp As AFTime
+      ' Returns a value only if no time context is given. Without a time
+      ' context, the value for the current timestamp is returned. This is done
+      ' so that backfilling or recalculating with the PI Analysis Service does
+      ' not slow down the system and cause skipped calculations because of a
+      ' synclocked DBM object. For analysis of historic timestamps over a time
+      ' range, the GetValues method should be used.
 
       If timeContext Is Nothing Then
-        Timestamp = Now
+        Return DBMResult(Now)
       Else
-        Timestamp = DirectCast(timeContext, AFTime)
+        Return CreateSystemStateValue(NoSample,
+          DirectCast(timeContext, AFTime)) ' Return No Sample
       End If
-
-      Return DBMResult(Timestamp)
 
     End Function
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -195,7 +195,15 @@ Namespace Vitens.DynamicBandwidthMonitor
       Monitor.Enter(DBM) ' Request the lock, and block until it is obtained.
       Try
 
-        If PointsStale.IsStale Then UpdatePoints ' Update points periodically
+        Monitor.Enter(PointsStale) ' Request the lock, and block until obtained.
+        Try
+          If PointsStale.IsStale Then
+            UpdatePoints ' Update points periodically
+          End If
+        Finally
+          Monitor.Exit(PointsStale) ' Ensure that the lock is released.
+        End Try
+
         If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
           CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -256,9 +256,10 @@ Namespace Vitens.DynamicBandwidthMonitor
       End If
 
       ' Create a new DBM object for each call to the GetValue method. This is
-      ' done so that multiple parallel calls do not block execution (f.ex. when
-      ' performing real-time calculations using the PI Analysis Service). The
-      ' downside to this is that caching is not available.
+      ' done so that multiple parallel calls for a single value do not block
+      ' execution (for example when performing real-time calculations using the
+      ' PI Analysis Service). The downside to this is that caching is not
+      ' available.
       Return DBMResult(New DBM, Timestamp)
 
     End Function
@@ -279,9 +280,10 @@ Namespace Vitens.DynamicBandwidthMonitor
         CalculationInterval ' Required interval, first and last interv inclusive
       Do While timeContext.EndTime > timeContext.StartTime
         ' Use the shared DBM object for each call to the GetValues method. This
-        ' is done so caching is enabled when retrieving many values over a
-        ' period of time. A parallel call is blocked and executed after the data
-        ' has been cached for faster execution.
+        ' is done so that caching is enabled when retrieving multiple values
+        ' over a period of time. A parallel call is blocked and executed after
+        ' the data has been cached for faster execution and only a single call
+        ' to the PI Data Archive server.
         GetValues.Add(
           DBMResult(SharedDBM, timeContext.StartTime, timeContext.EndTime))
         timeContext.StartTime = New AFTime(

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -252,13 +252,13 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim Timestamp As AFTime
 
       If timeContext Is Nothing Then
-        Return DBMResult(NonsharedDBM, Now)
+        Return DBMResult(Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
         If Timestamp.IsEmpty Then
           Return CreateSystemStateValue(NoSample, Timestamp) ' Return No Sample
         Else
-          Return DBMResult(NonsharedDBM, Timestamp)
+          Return DBMResult(Timestamp)
         End If
       End If
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -212,20 +212,8 @@ Namespace Vitens.DynamicBandwidthMonitor
           Monitor.Exit(PointsStale) ' Ensure that the lock is released.
         End Try
 
-        If EndTimestamp.IsEmpty Then
-          ' Prepare data when no end timestamp is passed and data is only
-          ' required for calculation on a single timestamp, as done in the
-          ' GetValue method. In this case, add one calculation interval to the
-          ' end timestamp in the PrepareData call, as the end timestamp itself
-          ' is excluded there.
-          DBM.PrepareData(InputPointDriver, CorrelationPoints,
-            Timestamp.LocalTime, NextInterval(Timestamp.LocalTime))
-        Else
-          ' Prepare data when both a calculation timestamp and an end timestamp
-          ' are passed, as done in the GetValues method.
-          DBM.PrepareData(InputPointDriver, CorrelationPoints,
-            Timestamp.LocalTime, EndTimestamp.LocalTime)
-        End If
+        If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
+          CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
 
         With DBM.Result(
           InputPointDriver, CorrelationPoints, Timestamp.LocalTime)

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -26,7 +26,6 @@ Imports System
 Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.DateTime
-Imports System.Diagnostics.Process
 Imports System.Math
 Imports System.Runtime.InteropServices
 Imports System.Threading
@@ -74,7 +73,6 @@ Namespace Vitens.DynamicBandwidthMonitor
     Const CategoryNoCorrelation As String = "NoCorrelation"
     Const pValueLoHi As Double = 0.95 ' Confidence interval for Lo and Hi
     Const pValueMinMax As Double = 0.9999 ' CI for Minimum and Maximum
-    Const PIRecalcProcessName As String = "PIRecalculationProcessor"
 
 
     Private InputPointDriver As DBMPointDriver
@@ -249,17 +247,23 @@ Namespace Vitens.DynamicBandwidthMonitor
       timeContext As Object, inputAttributes As AFAttributeList,
       inputValues As AFValues) As AFValue
 
-      If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
-        ' No results are calculated for PI Analysis Service recalculations.
-        ' This is done so that backfilling or recalculating with the PI
-        ' Analysis Service does not slow down the system and cause skipped
-        ' calculations because of a synclocked DBM object.
-        Return New AFValue(0, DirectCast(timeContext, AFTime)) ' Return 0
+      Dim Timestamp As AFTime
+
+      If timeContext Is Nothing Then
+        ' Always returns a value for the current timestamp if no time context
+        ' is given.
+        Return DBMResult(Now)
       Else
-        If timeContext Is Nothing Then
-          Return DBMResult(Now)
+        Timestamp = DirectCast(timeContext, AFTime)
+        If (Now - Timestamp.LocalTime).TotalSeconds > CalculationInterval Then
+          ' Never return historic values older than one calculation interval.
+          ' This is done so that backfilling or recalculating with the PI
+          ' Analysis Service does not slow down the system and cause skipped
+          ' calculations because of a synclocked DBM object.
+          Return New AFValue(NaN, Timestamp)
         Else
-          Return DBMResult(DirectCast(timeContext, AFTime))
+          ' Only return historic values if within one calculation interval.
+          Return DBMResult(Timestamp)
         End If
       End If
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -249,18 +249,18 @@ Namespace Vitens.DynamicBandwidthMonitor
       timeContext As Object, inputAttributes As AFAttributeList,
       inputValues As AFValues) As AFValue
 
-      If timeContext Is Nothing Then
-        If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
-          ' No results are calculated for PI Analysis Service recalculations.
-          ' This is done so that backfilling or recalculating with the PI
-          ' Analysis Service does not slow down the system and cause skipped
-          ' calculations because of a synclocked DBM object.
-          Return Nothing
-        Else
-          Return DBMResult(Now)
-        End If
+      If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
+        ' No results are calculated for PI Analysis Service recalculations.
+        ' This is done so that backfilling or recalculating with the PI
+        ' Analysis Service does not slow down the system and cause skipped
+        ' calculations because of a synclocked DBM object.
+        Return New AFValue(0, DirectCast(timeContext, AFTime)) ' Return 0
       Else
-        Return DBMResult(DirectCast(timeContext, AFTime))
+        If timeContext Is Nothing Then
+          Return DBMResult(Now)
+        Else
+          Return DBMResult(DirectCast(timeContext, AFTime))
+        End If
       End If
 
     End Function

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -268,9 +268,10 @@ Namespace Vitens.DynamicBandwidthMonitor
       If timeContext Is Nothing Then
         ' Use the nonshared DBM object for each call to the GetValue method.
         ' This is done so that multiple parallel calls for a single value do not
-        ' block execution on the locked shared DBM object (for example when
-        ' performing real-time calculations using the PI Analysis Service). The
-        ' downside to this is that caching is not available.
+        ' block execution on the locked DBM object shared with all AF attributes
+        ' (for example when performing real-time calculations using the PI
+        ' Analysis Service). The downside to this is that caching is only
+        ' available per AF attribute.
         Return DBMResult(NonsharedDBM, Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
@@ -303,10 +304,11 @@ Namespace Vitens.DynamicBandwidthMonitor
         CalculationInterval ' Required interval, first and last interv inclusive
       Do While timeContext.EndTime > timeContext.StartTime
         ' Use the shared DBM object for each call to the GetValues method. This
-        ' is done so that caching is enabled when retrieving multiple values
-        ' over a period of time. A parallel call is blocked and executed after
-        ' the data has been cached for faster execution and only a single call
-        ' to the PI Data Archive server.
+        ' is done so that caching is enabled for all AF attributes when
+        ' retrieving multiple values over a period of time. A parallel call
+        ' to any AF attribute is blocked and executed after the data has been
+        ' cached for faster execution and only a single call to the PI Data
+        ' Archive server.
         GetValues.Add(
           DBMResult(SharedDBM, timeContext.StartTime, timeContext.EndTime))
         timeContext.StartTime = New AFTime(

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -267,7 +267,8 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(New DBM, Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
-        If AlignTimestamp(Timestamp.LocalTime).Equals(AlignTimestamp(Now)) Then
+        If AlignTimestamp(Timestamp.LocalTime, CalculationInterval).
+          Equals(AlignTimestamp(Now, CalculationInterval)) Then
           Return DBMResult(New DBM, Timestamp)
         Else
           ' Never return historic values older than one calculation interval.

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -202,7 +202,6 @@ Namespace Vitens.DynamicBandwidthMonitor
       Try
 
         If PointsStale.IsStale Then UpdatePoints ' Update points periodically
-
         If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
           CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
 
@@ -290,8 +289,7 @@ Namespace Vitens.DynamicBandwidthMonitor
         StartTime.UtcSeconds)/CalculationInterval-1)/(numberOfValues-1))*
         CalculationInterval ' Required interval, first and last interv inclusive
       Do While timeContext.EndTime > timeContext.StartTime
-        GetValues.Add(
-          DBMResult(SharedDBM, timeContext.StartTime, timeContext.EndTime))
+        GetValues.Add(DBMResult(timeContext.StartTime, timeContext.EndTime))
         timeContext.StartTime = New AFTime(
           timeContext.StartTime.UtcSeconds+IntervalSeconds)
       Loop

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -202,6 +202,7 @@ Namespace Vitens.DynamicBandwidthMonitor
       Try
 
         If PointsStale.IsStale Then UpdatePoints ' Update points periodically
+
         If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
           CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
 
@@ -289,7 +290,8 @@ Namespace Vitens.DynamicBandwidthMonitor
         StartTime.UtcSeconds)/CalculationInterval-1)/(numberOfValues-1))*
         CalculationInterval ' Required interval, first and last interv inclusive
       Do While timeContext.EndTime > timeContext.StartTime
-        GetValues.Add(DBMResult(timeContext.StartTime, timeContext.EndTime))
+        GetValues.Add(
+          DBMResult(SharedDBM, timeContext.StartTime, timeContext.EndTime))
         timeContext.StartTime = New AFTime(
           timeContext.StartTime.UtcSeconds+IntervalSeconds)
       Loop

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -263,20 +263,6 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(DirectCast(timeContext, AFTime))
       End If
 
-      If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
-        ' No results are calculated for PI Analysis Service recalculations. This
-        ' is done so that backfilling or recalculating with the PI Analysis
-        ' Service does not slow down the system and cause skipped calculations
-        ' because of a synclocked DBM object.
-        Return New AFValue(NaN,DirectCast(timeContext, AFTime))
-      Else
-        If timeContext Is Nothing Then
-          Return DBMResult(Now)
-        Else
-          Return DBMResult(DirectCast(timeContext, AFTime))
-        End If
-      End If
-
     End Function
 
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -259,8 +259,8 @@ Namespace Vitens.DynamicBandwidthMonitor
       If timeContext Is Nothing Then
         Return DBMResult(Now)
       Else
-        Return CreateSystemStateValue(NoSample,
-          DirectCast(timeContext, AFTime)) ' Return No Sample
+        Return CreateSystemStateValue(AccessDenied,
+          DirectCast(timeContext, AFTime)) ' Return Access Denied
       End If
 
     End Function

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -27,7 +27,6 @@ Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.DateTime
 Imports System.Diagnostics.Process
-Imports System.Double
 Imports System.Math
 Imports System.Runtime.InteropServices
 Imports System.Threading
@@ -249,6 +248,20 @@ Namespace Vitens.DynamicBandwidthMonitor
     Public Overrides Function GetValue(context As Object,
       timeContext As Object, inputAttributes As AFAttributeList,
       inputValues As AFValues) As AFValue
+
+      If timeContext Is Nothing Then
+        If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
+          ' No results are calculated for PI Analysis Service recalculations.
+          ' This is done so that backfilling or recalculating with the PI
+          ' Analysis Service does not slow down the system and cause skipped
+          ' calculations because of a synclocked DBM object.
+          Return Nothing
+        Else
+          Return DBMResult(Now)
+        End If
+      Else
+        Return DBMResult(DirectCast(timeContext, AFTime))
+      End If
 
       If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
         ' No results are calculated for PI Analysis Service recalculations. This

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -26,6 +26,7 @@ Imports System
 Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.DateTime
+Imports System.Double
 Imports System.Math
 Imports System.Runtime.InteropServices
 Imports System.Threading

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -75,6 +75,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     Const CategoryNoCorrelation As String = "NoCorrelation"
     Const pValueLoHi As Double = 0.95 ' Confidence interval for Lo and Hi
     Const pValueMinMax As Double = 0.9999 ' CI for Minimum and Maximum
+    Const AllowedGetValueOffsetDays As Double = 1 ' Allowed GetValue offset
 
 
     Private InputPointDriver As DBMPointDriver
@@ -275,13 +276,15 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(NonsharedDBM, Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
-        If Abs((Now - Timestamp.LocalTime).TotalDays) < 1 Then
+        If Abs((Now - Timestamp.LocalTime).TotalDays) <
+          AllowedGetValueOffsetDays Then
           Return DBMResult(NonsharedDBM, Timestamp)
         Else
-          ' Never calculate historic values older or newer than one day. This is
-          ' done so that backfilling or recalculating with the PI Analysis
-          ' Service does not slow down the system. For analysis of historic
-          ' timestamps over a time range, the GetValues method should be used.
+          ' Never calculate historic values older or newer than the specified
+          ' number of days. This is done so that backfilling or recalculating
+          ' with the PI Analysis Service does not slow down the system. For
+          ' analysis of historic timestamps over a time range, the GetValues
+          ' method should be used.
           Return CreateSystemStateValue(NoSample, Timestamp) ' Return No Sample
         End If
       End If

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -193,12 +193,11 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim AlignedTimestamp As AFTime ' DST issue with DateTime obj in DBMResult
       Dim Value As New AFValue
 
+      ' Attempts to acquire an exclusive lock on the DBM object for one
+      ' calculation interval.
       If Monitor.TryEnter(DBM, CalculationInterval * 1000) Then
 
-        ' Attempts to acquire an exclusive lock on the specified object for
-        ' 500 milliseconds.
         ' Lock was acquired.
-
         Try
 
           If PointsStale.IsStale Then UpdatePoints ' Update points periodically

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -196,9 +196,16 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim Value As New AFValue
 
       Monitor.Enter(DBM) ' Request the lock, and block until it is obtained.
+      ' We lock the DBM object so that when there are parallel calls, data will
+      ' be retrieved and cached only for the first call. Subsequent calls can
+      ' then use these cached values for faster calculation execution.
       Try
 
         Monitor.Enter(PointsStale) ' Request the lock, and block until obtained.
+        ' We lock the PointsStale object so that points are only updated once
+        ' every calculation interval. Because multiple instances of the DBM
+        ' object might exist and be active, we have to apply an additional lock
+        ' here after already locking the DBM object before.
         Try
           If PointsStale.IsStale Then UpdatePoints ' Update points periodically
         Finally

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -75,7 +75,6 @@ Namespace Vitens.DynamicBandwidthMonitor
     Const pValueLoHi As Double = 0.95 ' Confidence interval for Lo and Hi
     Const pValueMinMax As Double = 0.9999 ' CI for Minimum and Maximum
 
-
     Private InputPointDriver As DBMPointDriver
     Private CorrelationPoints As List(Of DBMCorrelationPoint)
     Private PointsStale As New DBMStale

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -75,6 +75,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     Const pValueLoHi As Double = 0.95 ' Confidence interval for Lo and Hi
     Const pValueMinMax As Double = 0.9999 ' CI for Minimum and Maximum
 
+
     Private InputPointDriver As DBMPointDriver
     Private CorrelationPoints As List(Of DBMCorrelationPoint)
     Private PointsStale As New DBMStale

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -36,6 +36,7 @@ Imports OSIsoft.AF.Asset.AFValue
 Imports OSIsoft.AF.Data
 Imports OSIsoft.AF.Time
 Imports Vitens.DynamicBandwidthMonitor.DBMInfo
+Imports Vitens.DynamicBandwidthMonitor.DBMMath
 Imports Vitens.DynamicBandwidthMonitor.DBMParameters
 
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -197,9 +197,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
         Monitor.Enter(PointsStale) ' Request the lock, and block until obtained.
         Try
-          If PointsStale.IsStale Then
-            UpdatePoints ' Update points periodically
-          End If
+          If PointsStale.IsStale Then UpdatePoints ' Update points periodically
         Finally
           Monitor.Exit(PointsStale) ' Ensure that the lock is released.
         End Try

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -251,7 +251,10 @@ Namespace Vitens.DynamicBandwidthMonitor
       inputValues As AFValues) As AFValue
 
       If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
-        ' No results are calculated for PI Analysis Service recalculations
+        ' No results are calculated for PI Analysis Service recalculations. This
+        ' is done so that backfilling or recalculating with the PI Analysis
+        ' Service does not slow down the system and cause skipped calculations
+        ' because of a synclocked DBM object.
         Return New AFValue(NaN,DirectCast(timeContext, AFTime))
       Else
         If timeContext Is Nothing Then

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -80,8 +80,8 @@ Namespace Vitens.DynamicBandwidthMonitor
     Private InputPointDriver As DBMPointDriver
     Private CorrelationPoints As List(Of DBMCorrelationPoint)
     Private PointsStale As New DBMStale
-    Private Shared SharedDBM As New DBM
     Private NonsharedDBM As New DBM
+    Private Shared SharedDBM As New DBM
 
 
     Public Overrides Readonly Property SupportedContexts _

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -36,7 +36,6 @@ Imports OSIsoft.AF.Asset.AFValue
 Imports OSIsoft.AF.Data
 Imports OSIsoft.AF.Time
 Imports Vitens.DynamicBandwidthMonitor.DBMInfo
-Imports Vitens.DynamicBandwidthMonitor.DBMMath
 Imports Vitens.DynamicBandwidthMonitor.DBMParameters
 
 
@@ -259,15 +258,14 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
-        If AlignTimestamp(Timestamp.LocalTime, CalculationInterval).
-          Equals(AlignTimestamp(Now, CalculationInterval)) Then
+        If (Now - Timestamp.LocalTime).TotalDays >= 0 And
+          (Now - Timestamp.LocalTime).TotalDays < 1 Then
           Return DBMResult(Timestamp)
         Else
-          ' Never return historic values older than one calculation interval.
-          ' This is done so that backfilling or recalculating with the PI
-          ' Analysis Service does not slow down the system. For analysis of
-          ' historic timestamps over a time range, the GetValues method should
-          ' be used.
+          ' Never calculate historic values older than one day. This is done so
+          ' that backfilling or recalculating with the PI Analysis Service does
+          ' not slow down the system. For analysis of historic timestamps over
+          ' a time range, the GetValues method should be used.
           Return CreateSystemStateValue(NoSample, Timestamp) ' Return No Sample
         End If
       End If

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -81,7 +81,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     Private InputPointDriver As DBMPointDriver
     Private CorrelationPoints As List(Of DBMCorrelationPoint)
     Private PointsStale As New DBMStale
-    Private Shared SharedDBM As New DBM
+    Private Shared DBM As New DBM
 
 
     Public Overrides Readonly Property SupportedContexts _
@@ -187,7 +187,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     End Sub
 
 
-    Private Function DBMResult(ByRef DBM As DBM, Timestamp As AFTime,
+    Private Function DBMResult(Timestamp As AFTime,
       Optional EndTimestamp As AFTime = Nothing) As AFValue
 
       ' Return DBM result parameter based on applied property/trait.
@@ -201,16 +201,7 @@ Namespace Vitens.DynamicBandwidthMonitor
       ' then use these cached values for faster calculation execution.
       Try
 
-        Monitor.Enter(PointsStale) ' Request the lock, and block until obtained.
-        ' We lock the PointsStale object so that points are only updated once
-        ' every calculation interval. Because multiple instances of the DBM
-        ' object might exist and be active, we have to apply an additional lock
-        ' here after already locking the DBM object before.
-        Try
-          If PointsStale.IsStale Then UpdatePoints ' Update points periodically
-        Finally
-          Monitor.Exit(PointsStale) ' Ensure that the lock is released.
-        End Try
+        If PointsStale.IsStale Then UpdatePoints ' Update points periodically
 
         If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
           CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
@@ -266,17 +257,12 @@ Namespace Vitens.DynamicBandwidthMonitor
       Dim Timestamp As AFTime
 
       If timeContext Is Nothing Then
-        ' Create a new DBM object for each call to the GetValue method. This is
-        ' done so that multiple parallel calls for a single value do not block
-        ' execution (for example when performing real-time calculations using
-        ' the PI Analysis Service). The downside to this is that caching is not
-        ' available.
-        Return DBMResult(New DBM, Now)
+        Return DBMResult(Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
         If AlignTimestamp(Timestamp.LocalTime, CalculationInterval).
           Equals(AlignTimestamp(Now, CalculationInterval)) Then
-          Return DBMResult(New DBM, Timestamp)
+          Return DBMResult(Timestamp)
         Else
           ' Never return historic values older than one calculation interval.
           ' This is done so that backfilling or recalculating with the PI
@@ -304,11 +290,6 @@ Namespace Vitens.DynamicBandwidthMonitor
         StartTime.UtcSeconds)/CalculationInterval-1)/(numberOfValues-1))*
         CalculationInterval ' Required interval, first and last interv inclusive
       Do While timeContext.EndTime > timeContext.StartTime
-        ' Use the shared DBM object for each call to the GetValues method. This
-        ' is done so that caching is enabled when retrieving multiple values
-        ' over a period of time. A parallel call is blocked and executed after
-        ' the data has been cached for faster execution and only a single call
-        ' to the PI Data Archive server.
         GetValues.Add(
           DBMResult(SharedDBM, timeContext.StartTime, timeContext.EndTime))
         timeContext.StartTime = New AFTime(

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -75,7 +75,7 @@ Namespace Vitens.DynamicBandwidthMonitor
     Const CategoryNoCorrelation As String = "NoCorrelation"
     Const pValueLoHi As Double = 0.95 ' Confidence interval for Lo and Hi
     Const pValueMinMax As Double = 0.9999 ' CI for Minimum and Maximum
-    Const RecalcProcess As String = "PIRecalculationProcessor"
+    Const PIRecalcProcessName As String = "PIRecalculationProcessor"
 
 
     Private InputPointDriver As DBMPointDriver
@@ -250,19 +250,15 @@ Namespace Vitens.DynamicBandwidthMonitor
       timeContext As Object, inputAttributes As AFAttributeList,
       inputValues As AFValues) As AFValue
 
-      ' When recalculating with the PI Analysis Service, returns a value only if
-      ' no time context is given. Without a time context, the value for the
-      ' current timestamp is returned. This is done so that backfilling or
-      ' recalculating does not slow down the system and cause skipped
-      ' calculations because of a synclocked DBM object. For all other
-      ' processes, values are returned as expected.
-
-      If timeContext Is Nothing Then
-        Return DBMResult(Now)
-      ElseIf GetCurrentProcess.ProcessName.Equals(RecalcProcess)
-        Return New AFValue(NaN, DirectCast(timeContext, AFTime))
+      If GetCurrentProcess.ProcessName.Equals(PIRecalcProcessName) Then
+        ' No results are calculated for PI Analysis Service recalculations
+        Return New AFValue(NaN,DirectCast(timeContext, AFTime))
       Else
-        Return DBMResult(DirectCast(timeContext, AFTime))
+        If timeContext Is Nothing Then
+          Return DBMResult(Now)
+        Else
+          Return DBMResult(DirectCast(timeContext, AFTime))
+        End If
       End If
 
     End Function

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -36,6 +36,7 @@ Imports OSIsoft.AF.Asset.AFValue
 Imports OSIsoft.AF.Data
 Imports OSIsoft.AF.Time
 Imports Vitens.DynamicBandwidthMonitor.DBMInfo
+Imports Vitens.DynamicBandwidthMonitor.DBMMath
 Imports Vitens.DynamicBandwidthMonitor.DBMParameters
 
 
@@ -258,14 +259,15 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
-        If (Now - Timestamp.LocalTime).TotalDays >= 0 And
-          (Now - Timestamp.LocalTime).TotalDays < 1 Then
+        If AlignTimestamp(Timestamp.LocalTime, CalculationInterval).
+          Equals(AlignTimestamp(Now, CalculationInterval)) Then
           Return DBMResult(Timestamp)
         Else
-          ' Never calculate historic values older than one day. This is done so
-          ' that backfilling or recalculating with the PI Analysis Service does
-          ' not slow down the system. For analysis of historic timestamps over
-          ' a time range, the GetValues method should be used.
+          ' Never return historic values older than one calculation interval.
+          ' This is done so that backfilling or recalculating with the PI
+          ' Analysis Service does not slow down the system. For analysis of
+          ' historic timestamps over a time range, the GetValues method should
+          ' be used.
           Return CreateSystemStateValue(NoSample, Timestamp) ' Return No Sample
         End If
       End If

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -260,7 +260,9 @@ Namespace Vitens.DynamicBandwidthMonitor
           ' Never return historic values older than one calculation interval.
           ' This is done so that backfilling or recalculating with the PI
           ' Analysis Service does not slow down the system and cause skipped
-          ' calculations because of a synclocked DBM object.
+          ' calculations because of a synclocked DBM object. NULL (year 1970)
+          ' timestamps are used when recalculating historic data. Even for
+          ' real-time calculations, a time context is always passed.
           Return New AFValue(NaN, Timestamp)
         Else
           ' Only return historic values if within one calculation interval.

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -36,7 +36,6 @@ Imports OSIsoft.AF.Asset.AFValue
 Imports OSIsoft.AF.Data
 Imports OSIsoft.AF.Time
 Imports Vitens.DynamicBandwidthMonitor.DBMInfo
-Imports Vitens.DynamicBandwidthMonitor.DBMMath
 Imports Vitens.DynamicBandwidthMonitor.DBMParameters
 
 
@@ -274,15 +273,14 @@ Namespace Vitens.DynamicBandwidthMonitor
         Return DBMResult(New DBM, Now)
       Else
         Timestamp = DirectCast(timeContext, AFTime)
-        If AlignTimestamp(Timestamp.LocalTime, CalculationInterval).
-          Equals(AlignTimestamp(Now, CalculationInterval)) Then
+        If (Now - Timestamp.LocalTime).TotalDays >= 0 And
+          (Now - Timestamp.LocalTime).TotalDays < 1 Then
           Return DBMResult(New DBM, Timestamp)
         Else
-          ' Never return historic values older than one calculation interval.
-          ' This is done so that backfilling or recalculating with the PI
-          ' Analysis Service does not slow down the system. For analysis of
-          ' historic timestamps over a time range, the GetValues method should
-          ' be used.
+          ' Never calculate historic values older than one day. This is done so
+          ' that backfilling or recalculating with the PI Analysis Service does
+          ' not slow down the system. For analysis of historic timestamps over
+          ' a time range, the GetValues method should be used.
           Return CreateSystemStateValue(NoSample, Timestamp) ' Return No Sample
         End If
       End If

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -212,8 +212,20 @@ Namespace Vitens.DynamicBandwidthMonitor
           Monitor.Exit(PointsStale) ' Ensure that the lock is released.
         End Try
 
-        If Not EndTimestamp.IsEmpty Then DBM.PrepareData(InputPointDriver,
-          CorrelationPoints, Timestamp.LocalTime, EndTimestamp.LocalTime)
+        If EndTimestamp.IsEmpty Then
+          ' Prepare data when no end timestamp is passed and data is only
+          ' required for calculation on a single timestamp, as done in the
+          ' GetValue method. In this case, add one calculation interval to the
+          ' end timestamp in the PrepareData call, as the end timestamp itself
+          ' is excluded there.
+          DBM.PrepareData(InputPointDriver, CorrelationPoints,
+            Timestamp.LocalTime, NextInterval(Timestamp.LocalTime))
+        Else
+          ' Prepare data when both a calculation timestamp and an end timestamp
+          ' are passed, as done in the GetValues method.
+          DBM.PrepareData(InputPointDriver, CorrelationPoints,
+            Timestamp.LocalTime, EndTimestamp.LocalTime)
+        End If
 
         With DBM.Result(
           InputPointDriver, CorrelationPoints, Timestamp.LocalTime)

--- a/src/dbm/DBMManifest.vb
+++ b/src/dbm/DBMManifest.vb
@@ -26,7 +26,7 @@ Option Strict
 ' returned using the DBM.Version function.
 
 
-<assembly:System.Reflection.AssemblyVersion("1.31.*")>
+<assembly:System.Reflection.AssemblyVersion("1.32.*")>
 
 <assembly:System.Reflection.AssemblyProduct("Dynamic Bandwidth Monitor")>
 


### PR DESCRIPTION
Fix an issue in the DBM Data Reference for OSIsoft PI where a lock on the DBM object can cause the PI Analysis Service to lock up during recalculation or backfilling.