### PR TITLE
AFDR: Mark events as questionable, and 2 bugfixes

### DIFF
--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -376,9 +376,10 @@ Namespace Vitens.DynamicBandwidthMonitor
         InputPointDriver = New DBMPointDriver(Attribute.Parent) ' Parent attrib.
 
         ' Retrieve correlation points from AF hierarchy for non-root elements
-        ' only when calculating the DBM factor value and if correlation
-        ' calculations are not disabled using categories.
-        If Not Element.IsRoot And Attribute.Trait Is Nothing And
+        ' only when calculating the DBM factor value or target, and if
+        ' correlation calculations are not disabled using categories.
+        If Not Element.IsRoot And
+          (Attribute.Trait Is Nothing Or Attribute.Trait Is LimitTarget) And
           Not Attribute.CategoriesString.Contains(CategoryNoCorrelation) Then
 
           ParentElement = Element.Parent

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -427,7 +427,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
           With Result
 
-            If Not TimeZoneInfo.Local.IsInvalidTime(.Timestamp) Then ' DST
+            If .TimestampIsValid Then
 
               If SupportsFutureData Or Not .IsFutureData Then
 

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -468,7 +468,7 @@ Namespace Vitens.DynamicBandwidthMonitor
               End If
               ' Mark events and forecast data as questionable.
               GetValues.Item(GetValues.Count-1).
-                Questionable = .Factor.HasEvent Or .IsFutureData
+                Questionable = .HasEvent Or .IsFutureData
             End If
 
           End With

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -27,6 +27,7 @@ Imports System.Collections.Generic
 Imports System.ComponentModel
 Imports System.DateTime
 Imports System.Double
+Imports System.Math
 Imports System.Runtime.InteropServices
 Imports OSIsoft.AF.Asset
 Imports OSIsoft.AF.Asset.AFAttributeTrait
@@ -471,9 +472,11 @@ Namespace Vitens.DynamicBandwidthMonitor
                   GetValues.Item(GetValues.Count-1).
                     Substituted = Not .IsFutureData
                 End If
-                ' Mark events and forecast data as questionable.
-                GetValues.Item(GetValues.Count-1).
-                  Questionable = .HasEvent Or .IsFutureData
+                ' Mark events (exceeding LimitMinimum and LimitMaximum control
+                ' limits) and forecast data as questionable.
+                GetValues.Item(GetValues.Count-1).Questionable = Abs(
+                  .ForecastItem.Measurement-.ForecastItem.Forecast) >
+                  .ForecastItem.Range(pValueMinMax) Or .IsFutureData
               End If
 
             End If

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -376,12 +376,11 @@ Namespace Vitens.DynamicBandwidthMonitor
         InputPointDriver = New DBMPointDriver(Attribute.Parent) ' Parent attrib.
 
         ' Retrieve correlation points from AF hierarchy for first-level child
-        ' attributes in non-root elements, only when calculating the DBM factor
-        ' or target value, and if correlation calculations are not disabled
-        ' using categories.
-        If Not Element.IsRoot And
-          Attribute.Parent.Parent Is Nothing And
-          (Attribute.Trait Is Nothing Or Attribute.Trait Is LimitTarget) And
+        ' attributes in non-root elements only when calculating the DBM factor
+        ' value and if correlation calculations are not disabled using
+        ' categories.
+        If Not Element.IsRoot And Attribute.Parent.Parent Is Nothing And
+          Attribute.Trait Is Nothing And
           Not Attribute.CategoriesString.Contains(CategoryNoCorrelation) Then
 
           ParentElement = Element.Parent

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -456,15 +456,19 @@ Namespace Vitens.DynamicBandwidthMonitor
 
             End If
 
-            ' Augment Trait data with Forecast data.
-            If Attribute.Trait Is LimitTarget And
-              (IsNaN(.ForecastItem.Measurement) Or .IsFutureData) Then
-              ' Replace missing historic Target data with Forecast data, marked
-              ' as substituted, and append Forecast data to Target in the
-              ' future, marked as questionable.
-              GetValues.Item(GetValues.Count-1).Value = .ForecastItem.Forecast
-              GetValues.Item(GetValues.Count-1).Substituted = Not .IsFutureData
-              GetValues.Item(GetValues.Count-1).Questionable = .IsFutureData
+            ' Augment target data with forecast.
+            If Attribute.Trait Is LimitTarget Then
+              If IsNaN(.ForecastItem.Measurement) Or .IsFutureData Then
+                ' Replace missing data with forecast, append forecast data to
+                ' the future.
+                GetValues.Item(GetValues.Count-1).Value = .ForecastItem.Forecast
+                ' Mark replaced data as substituted.
+                GetValues.Item(GetValues.Count-1).
+                  Substituted = Not .IsFutureData
+              End If
+              ' Mark events and forecast data as questionable.
+              GetValues.Item(GetValues.Count-1).
+                Questionable = .Factor.HasEvent Or .IsFutureData
             End If
 
           End With

--- a/src/PIAFDataRef/DBMDataRef.vb
+++ b/src/PIAFDataRef/DBMDataRef.vb
@@ -375,10 +375,12 @@ Namespace Vitens.DynamicBandwidthMonitor
         Element = DirectCast(Attribute.Element, AFElement)
         InputPointDriver = New DBMPointDriver(Attribute.Parent) ' Parent attrib.
 
-        ' Retrieve correlation points from AF hierarchy for non-root elements
-        ' only when calculating the DBM factor value or target, and if
-        ' correlation calculations are not disabled using categories.
+        ' Retrieve correlation points from AF hierarchy for first-level child
+        ' attributes in non-root elements, only when calculating the DBM factor
+        ' or target value, and if correlation calculations are not disabled
+        ' using categories.
         If Not Element.IsRoot And
+          Attribute.Parent.Parent Is Nothing And
           (Attribute.Trait Is Nothing Or Attribute.Trait Is LimitTarget) And
           Not Attribute.CategoriesString.Contains(CategoryNoCorrelation) Then
 

--- a/src/dbm/DBMPoint.vb
+++ b/src/dbm/DBMPoint.vb
@@ -4,7 +4,7 @@ Option Strict
 
 ' Dynamic Bandwidth Monitor
 ' Leak detection method implemented in a real-time data historian
-' Copyright (C) 2014-2020  J.H. Fitié, Vitens N.V.
+' Copyright (C) 2014-2021  J.H. Fitié, Vitens N.V.
 '
 ' This file is part of DBM.
 '
@@ -156,12 +156,7 @@ Namespace Vitens.DynamicBandwidthMonitor
 
         Next CorrelationCounter
 
-        ' Add results only for valid timestamps. This fixes an issue where, when
-        ' DST goes in effect, there is a missing hour in local time.
-        If Not TimeZoneInfo.Local.IsInvalidTime(Result.Timestamp) Then
-          GetResults.Add(Result)
-        End If
-
+        GetResults.Add(Result) ' Add timestamp results.
         StartTimestamp =
           StartTimestamp.AddSeconds(TimeRangeInterval) ' Next interval.
 

--- a/src/dbm/DBMResult.vb
+++ b/src/dbm/DBMResult.vb
@@ -4,7 +4,7 @@ Option Strict
 
 ' Dynamic Bandwidth Monitor
 ' Leak detection method implemented in a real-time data historian
-' Copyright (C) 2014-2020  J.H. Fitié, Vitens N.V.
+' Copyright (C) 2014-2021  J.H. Fitié, Vitens N.V.
 '
 ' This file is part of DBM.
 '
@@ -76,6 +76,16 @@ Namespace Vitens.DynamicBandwidthMonitor
           (.Measurement < .LowerControlLimit Or
           .Measurement > .UpperControlLimit)
       End With
+
+    End Function
+
+
+    Public Function TimestampIsValid As Boolean
+
+      ' Returns true if the timestamp is valid. When DST goes in effect, there
+      ' is a missing hour in local time.
+
+      Return Not TimeZoneInfo.Local.IsInvalidTime(Timestamp)
 
     End Function
 


### PR DESCRIPTION
* Mark events as questionable
* Only use correlation data for first-level child attributes
* Only return data with valid timestamps (DST issue)