### PR TITLE
TARDA-2840 Refactor DBMDataRef for thread-safe annotation access and …

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # DBM
 Dynamic Bandwidth Monitor\
 Leak detection method implemented in a real-time data historian\
-Copyright (C) 2014-2024  J.H. Fitié, Vitens N.V.
+Copyright (C) 2014-2025  J.H. Fitié, Vitens N.V.
 
 ## Description
 Water company Vitens has created a demonstration site called the Vitens Innovation Playground (VIP), in which new technologies and methodologies are developed, tested, and demonstrated. The projects conducted in the demonstration site can be categorized into one of four themes: energy optimization, real-time leak detection, online water quality monitoring, and customer interaction. In the real-time leak detection theme, a method for leak detection based on statistical demand forecasting was developed.

--- a/src/dbm/DBMManifest.vb
+++ b/src/dbm/DBMManifest.vb
@@ -1,6 +1,6 @@
 ' Dynamic Bandwidth Monitor
 ' Leak detection method implemented in a real-time data historian
-' Copyright (C) 2014-2024  J.H. Fitié, Vitens N.V.
+' Copyright (C) 2014-2025  J.H. Fitié, Vitens N.V.
 '
 ' This file is part of DBM.
 '
@@ -30,6 +30,6 @@
   "Leak detection method implemented in a real-time data historian")>
 
 <assembly:System.Reflection.AssemblyCopyright(
-  "Copyright (C) 2014-2024  J.H. Fitié, Vitens N.V.")>
+  "Copyright (C) 2014-2025  J.H. Fitié, Vitens N.V.")>
 
 <assembly:System.Reflection.AssemblyCompany("Vitens N.V.")>


### PR DESCRIPTION
…memory-efficient size limiting (#327) (#328)

* Thread-safe access to _annotations in DBMDataRef using lock



* Limit _annotations dictionary size to 10,000 by removing entries when exceeded



* Refactor to use constant for maximum annotations size



* Refactor _annotations to use SortedDictionary for FIFO eviction instead of random removal



* Limit line length correctly



* Update copyright year, change maximum number of annotations



---------